### PR TITLE
updated add_splines error and unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hotfun
 Title: Collection of Functions Used in the Health Outcomes Team
     at MSKCC
-Version: 0.1.9
+Version: 0.1.10
 Authors@R: 
     person(given = "Daniel D.",
            family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hotfun 0.1.10
+
+- Added error message to `add_splines()` when new variable names already exist in data frame.
+
 # hotfun 0.1.9
 
 - Added function `add_splines()` to calculate spline terms and attach the spline terms and knots to the original data

--- a/R/add_splines.R
+++ b/R/add_splines.R
@@ -34,6 +34,15 @@ add_splines <- function(data, variable, knots = NULL, nk = 5, norm = 2, new_name
   else if (is.null(new_names)) new_names <- paste0("sp", variable, seq(1, ncol(df_sp)))
   names(df_sp) <- new_names
 
+  # check names (given or default) do not already exist in data
+  if (length(intersect(names(data), new_names)) > 0) {
+    stop(
+      stringr::str_glue(
+        "The variable(s) {glue::glue_collapse(intersect(names(data), new_names), sep = ', ')} already exist in this dataset"
+        ), call. = FALSE
+    )
+  }
+
   # combining original data with splines ---------------------------------------
   df_return <-
     dplyr::bind_cols(data, df_sp) %>%

--- a/tests/testthat/test-add_splines.R
+++ b/tests/testthat/test-add_splines.R
@@ -1,0 +1,32 @@
+context("get_mode")
+
+library(gtsummary)
+
+test_that("add_spline function gives error if spline variable names exist", {
+
+  # Error if not specifying variable names and they already exist
+  expect_error(
+    trial %>%
+      hotfun::add_splines(variable = age) %>%
+      hotfun::add_splines(variable = age),
+    "*"
+  )
+
+  # No error if specifying variable names and default variable names already exist
+  expect_error(
+    trial %>%
+      hotfun::add_splines(variable = age) %>%
+      hotfun::add_splines(variable = age, new_names = c("sptest1", "sptest2", "sptest3")),
+    NA
+  )
+
+  # Error if specifying variable names and they already exist
+  expect_error(
+    trial %>%
+      hotfun::add_splines(variable = age, new_names = c("sptest1", "sptest2", "sptest3")) %>%
+      hotfun::add_splines(variable = age, new_names = c("sptest1", "sptest2", "sptest3")),
+    "*"
+  )
+
+
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**

This adds an error message that stops the code if the names of the spline variables (either default or user-supplied) already exist in the data. It also adds relevant unit tests for this fix.

**If there is an GitHub issue associated with this pull request, please provide link.**


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch
- [x] NEWS.md has been updated
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, function included in `pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`.
- [x] R CMD Check runs without errors, warnings, and notes

If you **are NOT** making a release

- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")` and merge the PR.

If you **are** making a release

- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "patch")` and merge the PR.
- *After the pull request has been merged*
  - Run `usethis::use_github_release()`
  - Publish the GitHub release
